### PR TITLE
Upgrading to new profile fields

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -130,8 +130,8 @@ class Strategy extends OAuth2Strategy {
     return {
       id: json.account_id,
       displayName: json.name,
-      email: json.email,
-      photo: json.picture,
+      emails: [{ value: json.email, verified: json.email_verified }],
+      photos: [{ value: json.picture }],
     };
   }
 }


### PR DESCRIPTION
Updating returned profile fields.


According to typescript package `@types/passport`,  the method `_convertProfileFields` should now returns: `emails` and `photos` instead of `email` and `photo`

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9ed456704eae9073f90b5763ffc2f911032bb13e/types/passport/index.d.ts#L160-L166